### PR TITLE
Externalize PixiJS dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,12 +20,12 @@
   },
   "dependencies": {
     "keyb": "^1.1.0",
-    "pixi.js": "^4.5.5",
     "statgrab": "^1.2.0",
     "yaafloop": "^1.1.0"
   },
   "devDependencies": {
     "babel-preset-es2015": "^6.24.1",
-    "codeglue": "^1.3.0"
+    "codeglue": "^1.3.0",
+    "pixi.js": "^4.5.6"
   }
 }

--- a/source/index.html
+++ b/source/index.html
@@ -10,6 +10,7 @@
     </head>
     <body>
         <div id="frame"></div>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/pixi.js/4.5.6/pixi.min.js"></script>
         <script src="index.js"></script>
     </body>
 </html>

--- a/source/index.js
+++ b/source/index.js
@@ -1,9 +1,8 @@
-import * as Pixi from "pixi.js"
 import Yaafloop from "yaafloop"
 import Dude from "./scripts/Dude.js"
 import {FRAME} from "scripts/Constants"
 
-var renderer = Pixi.autoDetectRenderer({
+var renderer = PIXI.autoDetectRenderer({
     width: FRAME.WIDTH,
     height: FRAME.HEIGHT,
     transparent: true
@@ -11,7 +10,7 @@ var renderer = Pixi.autoDetectRenderer({
 
 document.getElementById("frame").appendChild(renderer.view)
 
-class Game extends Pixi.Container {
+class Game extends PIXI.Container {
     constructor() {
         super()
         this.addChild(new Dude())

--- a/source/scripts/Dude.js
+++ b/source/scripts/Dude.js
@@ -1,11 +1,10 @@
-import * as Pixi from "pixi.js"
 import Keyb from "keyb"
 import {FRAME} from "scripts/Constants"
 
-Pixi.settings.SCALE_MODE = Pixi.SCALE_MODES.NEAREST
-var texture = Pixi.Texture.from(require("images/dude.png"))
+PIXI.settings.SCALE_MODE = PIXI.SCALE_MODES.NEAREST
+var texture = PIXI.Texture.from(require("images/dude.png"))
 
-export default class Dude extends Pixi.Sprite {
+export default class Dude extends PIXI.Sprite {
     constructor() {
         super(texture)
         


### PR DESCRIPTION
Improves incremental build times with side-benefits to initial build and
reload times.

Anecdotally, my incremental builds before the change were in the 0.8-1.5s
range and in the 0 - 0.6s range after.